### PR TITLE
Generic to string

### DIFF
--- a/src/first.rs
+++ b/src/first.rs
@@ -1,24 +1,18 @@
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::Debug,
-    hash::Hash,
-};
+use std::collections::{HashMap, HashSet};
 
-use crate::{production::Production, symbol::unique_symbols, terminal::Terminal, Symbol};
+use crate::{production::Production, symbol::unique_symbols, Symbol};
 
-pub fn compute_first_set<T: PartialEq + Clone + Eq + Debug + Hash + Terminal>(
-    productions: &Vec<Production<T>>,
-) -> HashMap<Symbol<T>, HashSet<T>> {
+pub fn compute_first_set(productions: &Vec<Production>) -> HashMap<Symbol, HashSet<String>> {
     let symbols = unique_symbols(productions);
 
-    let mut first_map: HashMap<Symbol<T>, HashSet<T>> = HashMap::new();
+    let mut first_map: HashMap<Symbol, HashSet<String>> = HashMap::new();
     for symbol in symbols.iter() {
         match symbol {
             Symbol::TERMINAL(terminal) => {
                 first_map.insert(symbol.clone(), HashSet::from([terminal.clone()]));
             }
             Symbol::NONTERMINAL(non_terminal) => {
-                let filter_by_head: Vec<T> = productions
+                let filter_by_head: Vec<String> = productions
                     .iter()
                     .filter(|prod| prod.head.eq(non_terminal))
                     .filter_map(|prod| match prod.body.first().unwrap() {

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -21,7 +21,7 @@ impl Grammar {
 macro_rules! grammar {
     (
         $terminal_type:ident,
-        $($head:ident -> $($([$terminal:expr])? $($non_terminal1:ident $non_terminal2:ident)?)|+);+
+        $($head:ident -> $([$($terminal:expr),+] $($non_terminal1:ident $non_terminal2:ident)?)|+);+
     ) => {{
         let mut grammar: Grammar= Grammar::new();
         $({

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -2,18 +2,15 @@
 
 use std::fmt::Debug;
 
-use crate::{production::Production, terminal::Terminal};
+use crate::production::Production;
 
 #[derive(Debug)]
-pub struct Grammar<T>
-where
-    T: Clone + PartialEq + Eq + Debug + Terminal,
-{
-    pub productions: Vec<Production<T>>,
+pub struct Grammar {
+    pub productions: Vec<Production>,
 }
 
-impl<T: Clone + Debug + PartialEq + Eq + Terminal> Grammar<T> {
-    pub fn new() -> Grammar<T> {
+impl Grammar {
+    pub fn new() -> Grammar {
         Grammar {
             productions: Vec::new(),
         }
@@ -24,16 +21,17 @@ impl<T: Clone + Debug + PartialEq + Eq + Terminal> Grammar<T> {
 macro_rules! grammar {
     (
         $terminal_type:ident,
-        $($head:ident -> $($terminal:path $([$non_terminal:ident])*)|+);*
+        $($head:ident -> $($([$terminal:expr])? $($non_terminal1:ident $non_terminal2:ident)?)|+);+
     ) => {{
-        let mut grammar: Grammar<$terminal_type> = Grammar::new();
+        let mut grammar: Grammar= Grammar::new();
         $({
-            $({let mut body_ : Vec<Symbol<$terminal_type>> = Vec::new();
-            body_.push(Symbol::TERMINAL($terminal));
+            $({let mut body_ : Vec<Symbol> = Vec::new();
+            $(body_.push(Symbol::TERMINAL($terminal.to_string()));)?
             $(
-                body_.push(Symbol::NONTERMINAL(stringify!($non_terminal).to_string()));
-            )*
-            let production:Production<$terminal_type> = Production {
+                body_.push(Symbol::NONTERMINAL(stringify!($non_terminal1).to_string()));
+                body_.push(Symbol::NONTERMINAL(stringify!($non_terminal2).to_string()));
+            )?
+            let production:Production = Production {
                 head: stringify!($head).to_string(),
                 body: body_,
                 cursor_pos: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,12 +48,15 @@ fn main() {
     let dummy = String::new();
     let grammar: Grammar = crate::grammar!(
         TokenType,
-        S -> A B;
+        S -> A B
+        |B C;
         A -> [TokenType::A];
-        B -> [TokenType::B]
+        B -> [TokenType::A];
+        C -> [TokenType::B]
     );
     let mut p = Parser::new(grammar.productions);
     p.compute_lr0_items();
-    let input = vec![TokenType::A, TokenType::A, TokenType::EOF];
-    p.parse(input);
+    println!("{:#?}", p.lr0_automaton);
+    // let input = vec![TokenType::A, TokenType::A, TokenType::EOF];
+    // p.parse(input);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,8 +48,8 @@ fn main() {
     let dummy = String::new();
     let grammar: Grammar = crate::grammar!(
         TokenType,
-        S -> A B
-        |B C;
+        S -> [TokenType::A,TokenType::B] A B
+        |[TokenType::B] B C;
         A -> [TokenType::A];
         B -> [TokenType::A];
         C -> [TokenType::B]

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,32 +20,40 @@ pub mod terminal;
 pub enum TokenType {
     A,
     B,
-    C,
+    C(String),
     EOF,
 }
 
 impl Terminal for TokenType {
-    fn get_ending_token() -> TokenType {
-        TokenType::EOF
+    fn get_ending_token() -> String {
+        TokenType::EOF.to_string()
+    }
+    fn to_string(&self) -> String {
+        match self {
+            TokenType::A => String::from("A"),
+            TokenType::B => String::from("B"),
+            TokenType::C(_) => String::from("C"),
+            TokenType::EOF => String::from("EOF"),
+        }
+    }
+}
+
+impl Terminal for String {
+    fn get_ending_token() -> String {
+        TokenType::get_ending_token()
     }
 }
 
 fn main() {
-    let grammar: Grammar<TokenType> = crate::grammar!(
+    let dummy = String::new();
+    let grammar: Grammar = crate::grammar!(
         TokenType,
-        S -> TokenType::A [E];
-        E -> TokenType::B [Z] [Z];
-        Z -> TokenType::C
+        S -> A B;
+        A -> [TokenType::A];
+        B -> [TokenType::B]
     );
-    //println!("{:#?}", grammar.productions);
     let mut p = Parser::new(grammar.productions);
     p.compute_lr0_items();
-    let input = vec![
-        TokenType::A,
-        TokenType::B,
-        TokenType::C,
-        TokenType::C,
-        TokenType::EOF,
-    ];
+    let input = vec![TokenType::A, TokenType::A, TokenType::EOF];
     p.parse(input);
 }

--- a/src/production.rs
+++ b/src/production.rs
@@ -21,4 +21,7 @@ impl Production {
     pub fn advance_cursor(&mut self) {
         self.cursor_pos += 1;
     }
+    pub fn is_augment_production(&self) -> bool {
+        self.head == String::from("S'")
+    }
 }

--- a/src/production.rs
+++ b/src/production.rs
@@ -1,20 +1,17 @@
 use std::fmt::Debug;
 
-use crate::{terminal::Terminal, Symbol};
+use crate::Symbol;
 
 #[derive(Debug, Clone, PartialEq, Default)]
-pub struct Production<T>
-where
-    T: Clone + Debug + PartialEq + Eq + Terminal,
-{
+pub struct Production {
     pub head: String,
-    pub body: Vec<Symbol<T>>,
+    pub body: Vec<Symbol>,
     pub cursor_pos: usize,
     pub index: usize,
 }
 
-impl<T: Clone + Debug + PartialEq + Eq + Terminal> Production<T> {
-    pub fn next_symbol(&self) -> Option<&Symbol<T>> {
+impl Production {
+    pub fn next_symbol(&self) -> Option<&Symbol> {
         if self.cursor_pos == self.body.len() {
             None
         } else {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,15 +1,12 @@
 use std::{collections::HashMap, fmt::Debug};
 
-use crate::{action::Action, production::Production, symbol::Symbol, terminal::Terminal};
+use crate::{action::Action, production::Production, symbol::Symbol};
 
 #[derive(Debug, Clone)]
-pub struct State<T>
-where
-    T: Clone + PartialEq + Eq + Debug + Terminal,
-{
+pub struct State {
     pub state: usize,
-    pub productions: Vec<Production<T>>,
-    pub transition_symbol: Symbol<T>,
-    pub action: HashMap<T, Action>,
+    pub productions: Vec<Production>,
+    pub transition_symbol: Symbol,
+    pub action: HashMap<String, Action>,
     pub goto: HashMap<String, usize>,
 }

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,21 +1,16 @@
 use std::fmt::Debug;
 
-use crate::{production::Production, terminal::Terminal};
+use crate::production::Production;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Symbol<T>
-where
-    T: PartialEq + Debug + Clone + Eq + Terminal,
-{
-    TERMINAL(T),
+pub enum Symbol {
+    TERMINAL(String),
     NONTERMINAL(String),
     NONE,
 }
 
-pub fn unique_symbols<T: PartialEq + Debug + Clone + Eq + Terminal>(
-    productions: &Vec<Production<T>>,
-) -> Vec<Symbol<T>> {
-    let mut symbols: Vec<Symbol<T>> = Vec::new();
+pub fn unique_symbols(productions: &Vec<Production>) -> Vec<Symbol> {
+    let mut symbols: Vec<Symbol> = Vec::new();
 
     for production in productions.iter() {
         for symbol in production.body.iter() {
@@ -24,12 +19,12 @@ pub fn unique_symbols<T: PartialEq + Debug + Clone + Eq + Terminal>(
             }
         }
     }
-
-    symbols.push(Symbol::TERMINAL(T::get_ending_token()));
+    //eofff
+    symbols.push(Symbol::TERMINAL(String::from("EOF")));
     symbols
 }
 
-impl<T: Debug + Clone + Eq + Terminal> Symbol<T> {
+impl Symbol {
     pub fn is_terminal(&self) -> bool {
         matches!(self, Symbol::TERMINAL(_))
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,3 +1,6 @@
 pub trait Terminal {
-    fn get_ending_token() -> Self;
+    fn get_ending_token() -> String;
+    fn to_string(&self) -> String {
+        String::new()
+    }
 }


### PR DESCRIPTION
* Removed Generic  Type of [T] terminals to String terminals to support something like Enums with values (i.e TokenType::IDENTIFIER("msd"))
* Changes Grammar format from CNF to nontermianl -> (terminal)+ (nonterminal)*